### PR TITLE
Allow google font loading over HTTPS, too

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>The Sci-Fi Challenge</title>
-    <link href='http://fonts.googleapis.com/css?family=Nixie+One' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Nixie+One' rel='stylesheet' type='text/css'>
     <style>
       .body {
 


### PR DESCRIPTION
My browser defaults to HTTPS on *.github.io pages. The Nixie One
font isnt' displayed in that case.

Signed-off-by: Elliot Voris elliot@voris.me
